### PR TITLE
Consistency of @deprecated comments for IntelliJ convert Java to Kotlin

### DIFF
--- a/src/main/java/burp/IHttpRequestResponsePersisted.java
+++ b/src/main/java/burp/IHttpRequestResponsePersisted.java
@@ -18,7 +18,7 @@ package burp;
 public interface IHttpRequestResponsePersisted extends IHttpRequestResponse
 {
     /**
-     * This method is deprecated and no longer performs any action.
+     * @deprecated This method is deprecated and no longer performs any action.
      */
     @Deprecated
     void deleteTempFiles();

--- a/src/main/java/burp/IScannerInsertionPoint.java
+++ b/src/main/java/burp/IScannerInsertionPoint.java
@@ -71,7 +71,7 @@ public interface IScannerInsertionPoint
     static final byte INS_URL_PATH_FOLDER = 0x21;
     /**
      * Used to indicate where the payload is inserted into a URL path folder.
-     * This is now deprecated; use <code>INS_URL_PATH_FOLDER</code> instead.
+     * @deprecated This is now deprecated; use <code>INS_URL_PATH_FOLDER</code> instead.
      */
     @Deprecated
     static final byte INS_URL_PATH_REST = INS_URL_PATH_FOLDER;

--- a/src/main/java/burp/ITempFile.java
+++ b/src/main/java/burp/ITempFile.java
@@ -26,7 +26,7 @@ public interface ITempFile
     byte[] getBuffer();
 
     /**
-     * This method is deprecated and no longer performs any action.
+     * @deprecated This method is deprecated and no longer performs any action.
      */
     @Deprecated
     void delete();


### PR DESCRIPTION
These "@deprecated" comment markers are required for IntelliJ to convert the API java files to Kotlin files correctly. When they aren't included the resulting Kotlin files have to be updated manually before they can be compiled (to avoid the following fatal error).

![image](https://user-images.githubusercontent.com/21125224/34655763-11db1ba4-f407-11e7-84d9-4df00eb4dd79.png)

See also:
https://github.com/bao7uo/burp-extender-api-kotlin